### PR TITLE
fix settings screen bugs, mostly effecting Android 12 / Pixel 6

### DIFF
--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -182,7 +182,7 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
       subTitleText: username,
       action: () => navigation.navigate("setUsername"),
       enabled: hasToken && !username,
-      greyed: !hasToken,
+      greyed: !hasToken || !!(hasToken && username),
     },
     {
       category: translate("common.language"),
@@ -243,9 +243,8 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
         if (setting.hidden) {
           return null
         }
-        const settingColor = setting.greyed ? palette.midGrey : null
+        const settingColor = setting.greyed ? palette.midGrey : palette.darkGrey
         const settingStyle: TextStyle = { color: settingColor }
-
         return (
           <React.Fragment key={`setting-option-${i}`}>
             <ListItem onPress={setting.action} disabled={!setting.enabled}>


### PR DESCRIPTION
Two issues:
1. Common issues on all devices - Username is not greyed out even when you are unable to change it.
2. Android 12 / Pixel 6 settings page coloring was breaking (white text on white background). To be honest, I don't know how this isn't a problem on all devices.

Issue:
![image](https://user-images.githubusercontent.com/11765428/145687448-1c90accd-9014-41ac-81f7-8cff6e6c91dc.png)


Resolved on my device (pixel 6, android 12):

![image](https://user-images.githubusercontent.com/11765428/145687461-3c56d23b-c96b-4621-bda5-25fb2aa52048.png)


Tested on iOS 15 / iPhone 13:

![image](https://user-images.githubusercontent.com/11765428/145687510-d610fb57-07e0-44c3-b963-8912a3dd3695.png)


Please review and let me know if there is a better way to solve this. I am brand new to React Native and this code base, so I am definitely learning. Thanks!