### PR TITLE
try setting default text color values here at a project wide level

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -3,6 +3,11 @@
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
+        <item name="android:textColor">#1d1d1d</item>
+        <item name="android:textColorPrimary">#1d1d1d</item>
+        <item name="android:textColorSecondary">#939AA4</item>
+        <item name="android:textColorTertiary">#315b5a</item>
+
     </style>
 
 </resources>


### PR DESCRIPTION
When some Android 12 devices are in Dark Mode, the app's default font color turned white, which was unreadable against the current project background color. This PR fixes that, making the app's default font color readable. 