### PR TITLE
move price-detail and settings icon to the header

### DIFF
--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -13,6 +13,7 @@ import EStyleSheet from "react-native-extended-stylesheet"
 import * as RNLocalize from "react-native-localize"
 import Icon from "react-native-vector-icons/Ionicons"
 import analytics from "@react-native-firebase/analytics"
+import { Button } from "react-native-elements"
 
 import { MAIN_QUERY } from "../graphql/query"
 import { translate } from "../i18n"
@@ -118,6 +119,14 @@ const styles = EStyleSheet.create({
     height: "10%",
     // height: '60rem'
     // height: 100
+  },
+  buttonStyleTime: {
+    backgroundColor: palette.white,
+    borderRadius: "38rem",
+    width: "50rem",
+  },
+  menuIcon: {
+    color: palette.darkGrey,
   },
 })
 
@@ -441,10 +450,34 @@ export const MoveMoneyNavigator: NavigatorType = () => (
       name="moveMoney"
       component={MoveMoneyScreenDataInjected}
       // options={{ title: translate("MoveMoneyScreen.title") }}
-      options={{
-        headerShown: false,
-        title: translate("MoveMoneyScreen.title"),
-      }}
+      options={({ navigation }) => {
+        return {
+          headerShown: true,
+          title: "", //translate("MoveMoneyScreen.title"),
+          headerLeft: (() => (
+            <Button
+              buttonStyle={styles.buttonStyleTime}
+              onPress={() =>
+                navigation.navigate("priceDetail", {
+                  account: AccountType.Bitcoin,
+                })
+              }
+              icon={<Icon name="ios-trending-up-outline" size={28} style={styles.menuIcon} />}
+            />
+          )
+          ),
+          headerRight: (() => (
+            <Button
+              buttonStyle={styles.buttonStyleTime}
+              onPress={() => navigation.navigate("settings")}
+              icon={<Icon name="ios-settings-outline" size={28} style={styles.menuIcon} />}
+            />
+          )
+          )
+
+        }
+      }
+      }
     />
   </StackMoveMoney.Navigator>
 )

--- a/app/screens/move-money-screen/move-money-screen.tsx
+++ b/app/screens/move-money-screen/move-money-screen.tsx
@@ -56,12 +56,6 @@ const styles = EStyleSheet.create({
     borderWidth: 2,
   },
 
-  buttonStyleTime: {
-    backgroundColor: palette.white,
-    borderRadius: "38rem",
-    width: "50rem",
-  },
-
   cover: { height: "100%", width: "100%" },
 
   divider: { flex: 1 },
@@ -90,17 +84,11 @@ const styles = EStyleSheet.create({
     marginTop: "24rem",
   },
 
-  menuIcon: {
-    color: palette.darkGrey,
-  },
-
   modal: { marginBottom: 0, marginHorizontal: 0 },
 
   screenStyle: {
     backgroundColor: palette.lighterGrey,
   },
-
-  separator: { marginTop: 32 },
 
   text: {
     color: palette.darkGrey,
@@ -335,23 +323,9 @@ export const MoveMoneyScreen: ScreenType = ({
         </View>
       </Modal>
       <View style={styles.header}>
-        <Button
-          buttonStyle={styles.buttonStyleTime}
-          containerStyle={styles.separator}
-          onPress={() =>
-            navigation.navigate("priceDetail", {
-              account: AccountType.Bitcoin,
-            })
-          }
-          icon={<Icon name="ios-trending-up-outline" size={32} style={styles.menuIcon} />}
-        />
+
         <BalanceHeader loading={loading} style={styles.balanceHeader} />
-        <Button
-          buttonStyle={styles.buttonStyleTime}
-          containerStyle={styles.separator}
-          onPress={() => navigation.navigate("settings")}
-          icon={<Icon name="ios-settings-outline" size={32} style={styles.menuIcon} />}
-        />
+
       </View>
 
       <FlatList


### PR DESCRIPTION
Move the `priceDetail` and `settings` icons to the navigation header. Allowing for more room for the currency amount to be displayed.

<img width="398" alt="Screen Shot 2021-12-14 at 7 57 11 PM" src="https://user-images.githubusercontent.com/16512926/146115263-416a9bda-954c-43a4-98a7-595a9d5245b9.png">
